### PR TITLE
feat(github): 선택한 운영 폼과 자동화 적용

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,44 @@
+name: 기능 요청
+description: 새로운 기능의 문제, 범위와 완료 조건을 기록합니다.
+title: "[기능] "
+labels:
+- type:기능
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: problem
+  attributes:
+    description: 문제에 관한 내용을 구체적으로 적어 주세요.
+    label: 문제
+  validations:
+    required: true
+- type: textarea
+  id: goal
+  attributes:
+    description: 목표에 관한 내용을 구체적으로 적어 주세요.
+    label: 목표
+  validations:
+    required: true
+- type: textarea
+  id: scope
+  attributes:
+    description: 범위에 관한 내용을 구체적으로 적어 주세요.
+    label: 범위
+  validations:
+    required: true
+- type: textarea
+  id: completion-criteria
+  attributes:
+    description: 완료 조건에 관한 내용을 구체적으로 적어 주세요.
+    label: 완료 조건
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/03-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-bug.yml
@@ -1,0 +1,44 @@
+name: 버그 보고
+description: 재현 가능한 오류와 기대 동작을 기록합니다.
+title: "[버그] "
+labels:
+- type:버그
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: current-behavior
+  attributes:
+    description: 현재 동작에 관한 내용을 구체적으로 적어 주세요.
+    label: 현재 동작
+  validations:
+    required: true
+- type: textarea
+  id: expected-behavior
+  attributes:
+    description: 기대 동작에 관한 내용을 구체적으로 적어 주세요.
+    label: 기대 동작
+  validations:
+    required: true
+- type: textarea
+  id: reproduction
+  attributes:
+    description: 재현 방법에 관한 내용을 구체적으로 적어 주세요.
+    label: 재현 방법
+  validations:
+    required: true
+- type: textarea
+  id: environment
+  attributes:
+    description: 환경에 관한 내용을 구체적으로 적어 주세요.
+    label: 환경
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/04-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/04-improvement.yml
@@ -1,0 +1,37 @@
+name: 개선 제안
+description: 기존 기능이나 사용성의 개선 방향을 기록합니다.
+title: "[개선] "
+labels:
+- type:개선
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: current-problem
+  attributes:
+    description: 현재 문제에 관한 내용을 구체적으로 적어 주세요.
+    label: 현재 문제
+  validations:
+    required: true
+- type: textarea
+  id: direction
+  attributes:
+    description: 개선 방향에 관한 내용을 구체적으로 적어 주세요.
+    label: 개선 방향
+  validations:
+    required: true
+- type: textarea
+  id: expected-effect
+  attributes:
+    description: 기대 효과에 관한 내용을 구체적으로 적어 주세요.
+    label: 기대 효과
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/09-design.yml
+++ b/.github/ISSUE_TEMPLATE/09-design.yml
@@ -1,0 +1,30 @@
+name: 디자인 작업
+description: UI·UX와 시각 요소의 요구사항을 기록합니다.
+title: "[디자인] "
+labels:
+- type:디자인
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: screen
+  attributes:
+    description: 대상 화면에 관한 내용을 구체적으로 적어 주세요.
+    label: 대상 화면
+  validations:
+    required: true
+- type: textarea
+  id: requirements
+  attributes:
+    description: 요구사항에 관한 내용을 구체적으로 적어 주세요.
+    label: 요구사항
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/10-content.yml
+++ b/.github/ISSUE_TEMPLATE/10-content.yml
@@ -1,0 +1,44 @@
+name: 콘텐츠 작업
+description: 글, 문구와 정적 콘텐츠의 작성·수정 범위를 기록합니다.
+title: "[콘텐츠] "
+labels:
+- type:콘텐츠
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: target
+  attributes:
+    description: 대상에 관한 내용을 구체적으로 적어 주세요.
+    label: 대상
+  validations:
+    required: true
+- type: textarea
+  id: purpose
+  attributes:
+    description: 목적에 관한 내용을 구체적으로 적어 주세요.
+    label: 목적
+  validations:
+    required: true
+- type: textarea
+  id: content
+  attributes:
+    description: 내용에 관한 내용을 구체적으로 적어 주세요.
+    label: 내용
+  validations:
+    required: true
+- type: textarea
+  id: location
+  attributes:
+    description: 게시 위치에 관한 내용을 구체적으로 적어 주세요.
+    label: 게시 위치
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/15-deployment.yml
+++ b/.github/ISSUE_TEMPLATE/15-deployment.yml
@@ -1,0 +1,44 @@
+name: 배포 작업
+description: 배포 대상, 검증과 복구 방법을 기록합니다.
+title: "[배포] "
+labels:
+- type:배포
+body:
+- type: markdown
+  attributes:
+    value: 같은 목적의 열린 Issue를 먼저 확인하고 저장소 정책에 맞는 추가 라벨을 지정해 주세요.
+- type: textarea
+  id: environment
+  attributes:
+    description: 환경에 관한 내용을 구체적으로 적어 주세요.
+    label: 환경
+  validations:
+    required: true
+- type: textarea
+  id: version
+  attributes:
+    description: 버전에 관한 내용을 구체적으로 적어 주세요.
+    label: 버전
+  validations:
+    required: true
+- type: textarea
+  id: verification
+  attributes:
+    description: 검증에 관한 내용을 구체적으로 적어 주세요.
+    label: 검증
+  validations:
+    required: true
+- type: textarea
+  id: rollback
+  attributes:
+    description: 복구에 관한 내용을 구체적으로 적어 주세요.
+    label: 복구
+  validations:
+    required: true
+- type: textarea
+  id: references
+  attributes:
+    description: 참고 자료에 관한 내용을 구체적으로 적어 주세요.
+    label: 참고 자료
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+---
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: '09:00'
+    timezone: Asia/Seoul
+  open-pull-requests-limit: 5
+  labels:
+  - type:의존성
+  groups:
+    minor-and-patch:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
+    security-updates:
+      applies-to: security-updates
+      patterns:
+      - "*"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: '09:00'
+    timezone: Asia/Seoul
+  open-pull-requests-limit: 5
+  labels:
+  - type:의존성
+  groups:
+    minor-and-patch:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
+    security-updates:
+      applies-to: security-updates
+      patterns:
+      - "*"

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,12 +1,12 @@
-name: Auto assign issues
-
-on:
+---
+name: Issue 담당자 자동 지정
+'on':
   issues:
-    types: [opened]
-
+    types:
+    - opened
 permissions:
+  contents: read
   issues: write
-
 jobs:
   assign:
-    uses: hadevyi/.github/.github/workflows/reusable-auto-assign.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-issue-auto-assign.yml@d96d2e5a4211d4eaacf576db094f354adff87aef

--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -1,0 +1,14 @@
+---
+name: PR 담당자 자동 지정
+'on':
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  assign:
+    uses: hadevyi/.github/.github/workflows/reusable-pull-request-auto-assign.yml@d96d2e5a4211d4eaacf576db094f354adff87aef

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+---
+name: Dependabot 조건부 자동 병합
+'on':
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  merge:
+    uses: hadevyi/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d96d2e5a4211d4eaacf576db094f354adff87aef

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: hadevyi/.github/.github/workflows/reusable-astro-pages.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-astro-pages.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
       public-ga-id: ${{ vars.PUBLIC_GA_ID }}
       public-google-site-verification: ${{ vars.PUBLIC_GOOGLE_SITE_VERIFICATION }}

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,34 @@
+---
+name: Discord GitHub 알림
+'on':
+  issues:
+    types:
+    - opened
+  issue_comment:
+    types:
+    - created
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+  workflow_run:
+    workflows:
+    - Node.js CI
+    - Project 이슈 상태 동기화
+    - Sync shared labels
+    - Deploy Astro site to GitHub Pages
+    - Dependabot 조건부 자동 병합
+    - PR 담당자 자동 지정
+    - Issue 담당자 자동 지정
+    types:
+    - completed
+permissions:
+  contents: read
+jobs:
+  notify:
+    uses: hadevyi/.github/.github/workflows/reusable-discord-notify.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
+    with:
+      bot-name: Spark Bot
+    secrets:
+      DISCORD_WEBHOOK_URL: "${{ secrets.DISCORD_WEBHOOK_URL }}"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,10 @@
+---
+name: Node.js CI
+'on':
+  pull_request: 
+  workflow_dispatch: 
+permissions:
+  contents: read
+jobs:
+  verify:
+    uses: hadevyi/.github/.github/workflows/reusable-node-ci.yml@d96d2e5a4211d4eaacf576db094f354adff87aef

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,16 +1,27 @@
+---
 name: Sync shared labels
-
-on:
+'on':
   workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        options:
+        - preview
+        - apply
+        default: preview
+      issue_number:
+        type: string
+        required: false
   schedule:
-    - cron: "8 9 13 * *"
-      timezone: "Asia/Seoul"
-
+  - cron: 8 9 13 * *
+    timezone: Asia/Seoul
 permissions:
   issues: write
-
 jobs:
   sync:
-    uses: hadevyi/.github/.github/workflows/reusable-sync-labels.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-sync-labels.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
-      profile: branding
+      profile: branding-site
+      mode: "${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'preview'
+        }}"
+      issue_number: "${{ inputs.issue_number || '' }}"

--- a/.github/workflows/sync-project-issues.yml
+++ b/.github/workflows/sync-project-issues.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   on-issue:
     if: github.event_name == 'issues'
-    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
       project_id: ${{ vars.PROJECT_ID }}
       mode: ${{ github.event.action }}
@@ -37,7 +37,7 @@ jobs:
 
   on-comment:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request == null
-    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
       project_id: ${{ vars.PROJECT_ID }}
       mode: comment
@@ -48,7 +48,7 @@ jobs:
 
   on-push:
     if: github.event_name == 'push'
-    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
       project_id: ${{ vars.PROJECT_ID }}
       mode: push
@@ -58,7 +58,7 @@ jobs:
 
   on-manual:
     if: github.event_name == 'workflow_dispatch'
-    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@main
+    uses: hadevyi/.github/.github/workflows/reusable-project-issue-sync.yml@d96d2e5a4211d4eaacf576db094f354adff87aef
     with:
       project_id: ${{ vars.PROJECT_ID }}
       mode: ${{ inputs.mode }}


### PR DESCRIPTION
## 변경 목적

확정된 저장소 운영 정책을 적용합니다.

## 주요 변경 내용

- 선택한 Issue Form 전체 묶음과 공통 PR 템플릿 상속
- 담당자·라벨·Discord 공통 호출과 주간 Dependabot 구성
- 선택한 사이트 CI·PDF 검사와 조건부 자동 병합, 기존 Pages·Project 보존
- 공통 호출을 전체 Commit SHA로 고정

## 연결된 Issue

Refs #57

## 검증 결과

- actionlint와 Git 공백 검사 통과
- 기존 라벨 연결 이전 및 분류 중복 검증 완료
- GitHub Actions의 구성된 PR 검사가 모두 성공했습니다. 원격 설정과 배포는 병합 후 확인합니다.

## 완료 체크리스트

- [x] 변경 범위가 연결된 Issue와 일치합니다.
- [x] 저장소에 구성된 테스트와 검증을 통과했습니다.
- [x] 필요한 문서를 함께 수정했습니다.
- [x] 호환성, 배포와 후속 작업을 아래에 기록했습니다.
- [x] Merge commit으로 병합할 준비가 되었습니다.

## 참고 사항

필수 CI가 검증된 사이트만 자동 병합을 활성화합니다. Major는 자동 병합하지 않습니다.
