### PR TITLE
fix(pages): 자동 병합 후 배포 누락 방지

### DIFF
--- a/.github/workflows/deploy-after-dependabot.yml
+++ b/.github/workflows/deploy-after-dependabot.yml
@@ -1,0 +1,17 @@
+name: Dependabot 병합 후 배포
+
+on:
+  workflow_run:
+    workflows:
+      - Node.js CI
+      - Dependabot 조건부 자동 병합
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+
+jobs:
+  deploy:
+    uses: hadevyi/.github/.github/workflows/reusable-deploy-after-dependabot.yml@89bfe77b28f1fa8c32671a9ba8c44761f334e8a4

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -14,6 +14,7 @@ name: Discord GitHub 알림
     - synchronize
   workflow_run:
     workflows:
+    - Dependabot 병합 후 배포
     - Node.js CI
     - Project 이슈 상태 동기화
     - Sync shared labels


### PR DESCRIPTION
## 변경 목적

GITHUB_TOKEN으로 자동 병합한 커밋이 Push 배포를 시작하지 않아 Pages가 이전 커밋에 머무는 문제를 해결합니다.

## 주요 변경 내용

검사 완료 이벤트에서 같은 저장소 main에 병합된 Dependabot PR을 확인하고, 현재 main의 배포가 없으면 기존 deploy.yml을 실행합니다. PR 코드를 Checkout하지 않으며 진행 중·성공 배포를 중복 실행하지 않습니다.

## 연결된 Issue

Refs #57

## 검증 결과

actionlint와 모의 API 테스트 6개 통과. 일반 PR·Fork·Major 제외, 병합 대기와 배포 중복 방지를 검증했습니다.

## 완료 체크리스트

- [x] 변경 범위가 연결된 Issue와 일치합니다.
- [x] 저장소에 구성된 테스트와 검증을 통과했습니다.
- [x] 필요한 문서를 함께 수정했습니다.
- [x] 호환성, 배포와 후속 작업을 아래에 기록했습니다.
- [x] Merge commit으로 병합할 준비가 되었습니다.

## 참고 사항

이 저장소의 완료 이벤트 호출을 추가하며 기존 Push·수동 Pages 배포는 유지합니다.
